### PR TITLE
fix: use vars to access variables instead of env in the workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,15 +29,15 @@ jobs:
       - name: Log in to the Container registry
         uses: docker/login-action@v3.2.0
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GH_TOKEN }}
+          registry: ${{ vars.REGISTRY }}
+          username: ${{ secrets.DOCKER_REGISTRY_UNAME }}
+          password: ${{ secrets.DOCKER_REGISTRY_PWD }}
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5.5.1
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ vars.REGISTRY }}/${{ vars.IMAGE_NAME }}
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
@@ -54,7 +54,7 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-name: ${{ vars.REGISTRY }}/${{ vars.IMAGE_NAME}}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
       


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#12](https://github.com/swazza/express-gp/pull/12))

### Other
- use vars to access variables instead of env in the workflow

### Uncategorised!
- Merge branch 'main' into fix-var-access-issue-in-workflow

<!--- END AUTOGENERATED NOTES --->