### PR TITLE
feat: bake git commit hash into image

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,1 +1,2 @@
 PORT=3000
+GIT_SHA=local

--- a/.github/workflows/on-merge-to-main.yml
+++ b/.github/workflows/on-merge-to-main.yml
@@ -37,3 +37,5 @@ jobs:
           sbom: true
           tags: ${{ steps.meta.outputs.tags }}
           annotations: ${{ steps.meta.outputs.annotations }}
+          build-args: |
+            GIT_SHA: ${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@
 # see all versions at https://hub.docker.com/r/oven/bun/tags
 FROM oven/bun:1.1.12-alpine as base
 WORKDIR /usr/src/app
+ARG GIT_SHA=local
+ENV GIT_SHA=$GIT_SHA
 ENV NODE_ENV=production
+ENV PORT=3000
+
 
 # install dependencies into temp directory
 # this will cache them and speed up future builds
@@ -20,7 +24,7 @@ RUN cd /temp/prod && bun install --production
 
 # copy production dependencies and source code into final image
 FROM base AS release
-ENV PORT=3000
+
 COPY --from=prerelease /temp/prod/node_modules node_modules
 COPY . .
 

--- a/src/app.spec.ts
+++ b/src/app.spec.ts
@@ -11,3 +11,14 @@ test("/", () => {
       if (err) throw err;
     });
 });
+
+test("/metadata", () => {
+  request(app)
+    .get("/metadata")
+    .expect(200)
+    .expect("Content-Type", /json/)
+    .end((err, res) => {
+      if (err) throw err;
+      expect(res.body.gitSHA).toBeString();
+    });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,12 @@ app.get("/", (req, res) => {
   res.send("Hello World!");
 });
 
+app.get("/metadata", (req, res) => {
+  res.json({
+    gitSHA: config.gitSHA,
+  });
+});
+
 export function start() {
   app.listen(config.port, () => {
     console.log(`Server is running on port ${config.port}`);

--- a/src/init/config.ts
+++ b/src/init/config.ts
@@ -2,8 +2,10 @@ import * as env from "env-var";
 
 export type Config = {
   port: number;
+  gitSHA: string;
 };
 
 export const config: Config = {
   port: env.get("PORT").required().asPortNumber(),
+  gitSHA: env.get("GIT_SHA").required().asString(),
 };


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#16](https://github.com/swazza/express-gp/pull/16))

### Other
- added support for git sha to be made available to the process
- git sha is now passed as docker build arg in github action
- added an endpoint to return the gitsha

<!--- END AUTOGENERATED NOTES --->